### PR TITLE
chore: Add lint/test action

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,48 @@
+---
+name: Linting and Test
+
+# Run for all pushes to main and pull requests when Go or YAML files change
+on:
+  push:
+    paths:
+      - go.mod
+      - go.sum
+      - '**.go'
+      - '**.yaml'
+    branches:
+      - main
+  pull_request:
+    paths:
+      - go.mod
+      - go.sum
+      - '**.go'
+      - '**.yaml'
+
+jobs:
+  golangci:
+    name: lint-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.42
+          args: --timeout=5m
+
+      - name: Run go tests and generate coverage report
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic -tags testtools -p 1 ./...
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.txt
+          flags: unittests
+          name: codecov-umbrella


### PR DESCRIPTION
This adds the new lint action from #1 separately so that the action can actually be ran in that PR since we should make sure it passes before merging.