### PR TITLE
goreleaser: Sign container images with cosign.

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           go-version: 1.17
       -
+        name: install cosign
+        uses: sigstore/cosign-installer@main
+      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,3 +51,32 @@ dockers:
     image_templates:
       - "ghcr.io/metal-toolbox/hollow-{{.ProjectName}}:{{ .Tag }}"
     dockerfile: Dockerfile
+
+sboms:
+  - artifacts: archive
+  - id: source
+    artifacts: source
+
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes" # required on cosign 2.0.0+
+    artifacts: all
+    output: true
+
+docker_signs:
+  - cmd: cosign
+    args:
+      - "sign"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "${artifact}"
+      - "--yes" # required on cosign 2.0.0+
+    artifacts: all
+    output: true


### PR DESCRIPTION
This commit modifies the goreleaser configuration to use Chainguard's cosign to sign container images. The diff is based on the goreleaser configuration found in metal-toolbox/flasher. [1]

cosign is an open-source tool that signs code and container images, allowing other users to cryptographically verify the origin of container images. [2]

cosign has different operating modes. This commit utilizes Chainguard's signing infrastructure via "keyless signing". [3] Keyless signing makes image signing easy for open-source projects because Chainguard operates the signing infrastructure on behalf of others.

The goreleaser configuration makes use of the "signs" and "docker_signs" plugins. [4] [5] The shell-like "$" references are magic variables that are documented in the referenced documentation.

References

1. https://github.com/metal-toolbox/flasher/blob/4e663e45288/.goreleaser.yaml#L59-L86
2. https://github.com/equinixmetal-buildkite/cosign-buildkite-plugin
3. https://edu.chainguard.dev/open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing
4. https://goreleaser.com/customization/sign/
5. https://goreleaser.com/customization/docker_sign/